### PR TITLE
Fix sidebar settings page scroll regression

### DIFF
--- a/public/styles/app-shell.css
+++ b/public/styles/app-shell.css
@@ -72,3 +72,20 @@
 .shell.no-boards .sidebar-edge-toggle {
   display: none;
 }
+
+@media (min-width: 901px) {
+  .shell {
+    height: 100vh;
+    height: 100dvh;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .sidebar {
+    min-height: 0;
+    max-height: 100vh;
+    max-height: 100dvh;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+}

--- a/test/e2e/ui-smoke.spec.ts
+++ b/test/e2e/ui-smoke.spec.ts
@@ -161,6 +161,7 @@ test("board renders and ticket dialog actions are wired", async ({ page }) => {
     await expect(page.locator("#sidebar .sidebar-github-link")).toHaveAttribute("href", "https://github.com/wamukat/kanbalone");
     await expect(page.locator("#sidebar .sidebar-github-link use[href='/icons.svg#github']")).toHaveCount(1);
     await expect(page.locator("#sidebar #footer-app-label")).toContainText("Kanbalone");
+    await page.setViewportSize({ width: 1280, height: 500 });
     await expect(page.locator("#board-settings-toggle-button use[href='/icons.svg#settings']")).toHaveCount(1);
     await expect(page.locator("#board-settings-toggle-button")).toHaveAttribute("aria-expanded", "false");
     await expect(page.locator("#sidebar-board-actions-panel")).toHaveAttribute("aria-hidden", "true");
@@ -171,6 +172,11 @@ test("board renders and ticket dialog actions are wired", async ({ page }) => {
     await expect(page.locator("#sidebar-board-actions-panel")).toHaveAttribute("aria-hidden", "false");
     await expect.poll(async () => page.locator("#sidebar-board-actions-panel").evaluate((panel) => panel.getBoundingClientRect().height)).toBeGreaterThan(0);
     await expect(page.locator("#sidebar-board-actions-panel .sidebar-board-panel-title")).toHaveCount(0);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => document.documentElement.scrollHeight <= document.documentElement.clientHeight),
+      )
+      .toBe(true);
     await expect
       .poll(async () =>
         page.evaluate(() => {


### PR DESCRIPTION
## Summary

- Keep the desktop app shell bound to the viewport when sidebar board settings are expanded.
- Move overflow ownership to the sidebar instead of allowing page-level vertical scroll.
- Add E2E coverage for the board settings panel scroll regression.

## Verification

- `pnpm exec playwright test test/e2e/ui-smoke.spec.ts --project=chromium`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e` (51/51)

Closes: Kanbalone#471
